### PR TITLE
Add Jekyll 4.x support

### DIFF
--- a/jekyll-json-feed.gemspec
+++ b/jekyll-json-feed.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r!^(test|spec|features)/!)
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "jekyll", "~> 3.3"
+  spec.add_dependency "jekyll", "~> 3.3", "~> 4.0"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/jekyll-json-feed.gemspec
+++ b/jekyll-json-feed.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r!^(test|spec|features)/!)
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "jekyll", "~> 3.3", "~> 4.0"
+  spec.add_dependency "jekyll", ">= 3.3", "< 5.0"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Just updated the dependency because it seems to work fine with the latest Jekyll version.