### PR TITLE
Move CI from Travis to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: Run Tests
+
+on: [push, pull_request]
+
+jobs:
+  run:
+    name: Ruby ${{ matrix.ruby }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [ 2.7, 2.6, 2.5 ]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+    - name: Run tests
+      run: script/cibuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: ruby
-rvm:
-- 2.2
-cache: bundler
-sudo: false
-before_script: bundle update
-script: "./script/cibuild"

--- a/jekyll-json-feed.gemspec
+++ b/jekyll-json-feed.gemspec
@@ -16,8 +16,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "jekyll", "~> 3.3"
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "kramdown-parser-gfm"
 end


### PR DESCRIPTION
This PR moves CI from Travis to GitHub Actions as there's no need to use Travis now we've got GitHub Actions. 