### PR TITLE
Update dev deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Gemfile.lock
 spec/dest
 .bundle
 spec/fixtures/.jekyll-metadata
+spec/fixtures/.jekyll-cache

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,9 @@
+require: rubocop-jekyll
 inherit_gem:
-  jekyll: .rubocop.yml
+  rubocop-jekyll: .rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.0
+  TargetRubyVersion: 2.4
   Include:
     - lib/*.rb
 

--- a/jekyll-json-feed.gemspec
+++ b/jekyll-json-feed.gemspec
@@ -17,8 +17,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "jekyll", ">= 3.3", "< 5.0"
 
   spec.add_development_dependency "bundler", "~> 2.1"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rake", "13.0"
+  spec.add_development_dependency "rspec", "3.10"
   spec.add_development_dependency "rubocop"
-  spec.add_development_dependency "kramdown-parser-gfm"
 end

--- a/jekyll-json-feed.gemspec
+++ b/jekyll-json-feed.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "13.0"
   spec.add_development_dependency "rspec", "3.10"
   spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "rubocop-jekyll"
 end

--- a/lib/jekyll-json-feed.rb
+++ b/lib/jekyll-json-feed.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "jekyll"
 require "fileutils"
 require "jekyll-json-feed/generator"


### PR DESCRIPTION
Updates dev dependencies and switch to using `rubocop-jekyll` for extended cops config.